### PR TITLE
Fix #3 - esbuild watch not rebuilding on changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ module.exports = options => {
 
         return {
           contents,
+          watchFiles: [args.path],
           loader: 'text'
         };
       });


### PR DESCRIPTION
Add the `watchFiles`  parameter so esbuild will watch the loaded file(s).