### PR TITLE
Fix TypeScript warning

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 
 import { Plugin } from 'esbuild';
 
-function esbuildPluginInlineImport(options?: {
+declare function esbuildPluginInlineImport(options?: {
   /**
    *  A regex filter to match the desired import. Defaults to imports that start with `inline:`, e.g.
    *  import 'inline:./file.ext';


### PR DESCRIPTION
Fixes this warning:

```
Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
```